### PR TITLE
6 enhancement support creation of multiple vms per lab user

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,14 +49,24 @@ The CLI provides simple commands to create, list, start, stop, and delete labs, 
      "postgres_user": "postgres",
      "postgres_password": "changeme",
      "postgres_db": "guacamole_db",
-     "connection_username": "student",
-     "connection_password": "student",
      "acme_email": "acme@openlab.io",
      "guacadmin_password": "changeme",
      "guacamole_instance_type": "t3.medium",
      "guacamole_ssh_key": "KeyPairMilan",
-     "instance_ami": "ami-00123456789abcdef",
-     "instance_type": "t3.medium",
+     "instances": [
+       {
+         "ami": "ami-06f70f6789ba21dc7",
+         "instance_type": "t3.medium",
+         "user": "student",
+         "password": "student"
+       },
+       {
+         "ami": "ami-06f70f6789ba21dc7",
+         "instance_type": "t3.medium",
+         "user": "student",
+         "password": "student"
+       }
+     ],
      "lab_users": ["user01", "user02"]
    }
    ```

--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ The core integrates three well known technologies:
 
 - Terraform and Ansible CLIs installed locally
 
+- `scicore.guacamole` Ansible module installed:
+
+  ```sh
+  ansible-galaxy collection install scicore.guacamole
+  ```
+
 ## Use the CLI
 
 The orchestration between Terraform and Ansible is done by the `openlab` CLI generated with [Bashly](https://bashly.dev/).
@@ -46,12 +52,8 @@ The CLI provides simple commands to create, list, start, stop, and delete labs, 
    ```json
    {
      "region": "eu-south-1",
-     "postgres_user": "postgres",
-     "postgres_password": "changeme",
-     "postgres_db": "guacamole_db",
      "acme_email": "acme@openlab.io",
      "guacadmin_password": "changeme",
-     "guacamole_instance_type": "t3.medium",
      "guacamole_ssh_key": "KeyPairMilan",
      "instances": [
        {

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -1,154 +1,33 @@
 ---
-- hosts: localhost
-  vars_files:
-    - ../terraform/terraform.tfvars.json
-    - ./vars.yaml # created on-the-fly by openlab CLI during lab creation (bashly/src/create_command.sh)
-
+- name: "Add users and connections to guacamole system"
+  hosts: localhost
   tasks:
-    - name: Check credentials file exists
-      ansible.builtin.stat:
-        path: "./{{lab_name}}/{{env}}/{{guacamole_fqdn}}_credentials.txt"
-      register: result
+    - name: "Waiting for Guacamole to become healthy"
+      ansible.builtin.wait_for:
+        timeout: 30
 
-    - name: Create token
-      ansible.builtin.uri:
-        url: https://{{guacamole_fqdn}}/guacamole/api/tokens
+    - name: "Add connections"
+      scicore.guacamole.guacamole_connection:
+        base_url: "{{ guacamole_url }}/guacamole"
         validate_certs: false
-        method: POST
-        body_format: form-urlencoded
-        body:
-          username: guacadmin
-          password: "{{guacadmin_password if result.stat.exists else 'guacadmin'}}"
-        status_code: 200
-      register: create_token_response
-      retries: 5
-      delay: 10
-      until: create_token_response is not failed
+        auth_username: "guacadmin"
+        auth_password: "guacadmin"
+        connection_name: "{{ item.owner }}-{{ item.private_ip | replace('.', '-') }}"
+        protocol: "rdp"
+        port: 3389
+        hostname: "{{ item.private_ip }}"
+        username: "{{ item.user }}"
+        password: "{{ item.password }}"
+      loop: "{{ instances }}"
+      register: connections
 
-    - name: Change guacadmin password
-      ansible.builtin.uri:
-        url: https://{{guacamole_fqdn}}/guacamole/api/session/data/postgresql/users/guacadmin/password?token={{create_token_response.json.authToken}}
+    - name: "Add users"
+      scicore.guacamole.guacamole_user:
+        base_url: "{{ guacamole_url }}/guacamole"
         validate_certs: false
-        method: PUT
-        body_format: json
-        body:
-          oldPassword: guacadmin
-          newPassword: "{{guacadmin_password}}"
-        status_code: 204
-      when: not result.stat.exists
-
-    - name: Check if user is present
-      ansible.builtin.uri:
-        url: https://{{guacamole_fqdn}}/guacamole/api/session/data/postgresql/users/{{item}}?token={{create_token_response.json.authToken}}
-        validate_certs: false
-        status_code:
-          - 200
-          - 404
-      loop: "{{lab_users}}"
-      register: check_user_response
-
-    # - name: Print check user response
-    #   ansible.builtin.debug:
-    #     msg: "{{item.status}}"
-    #   loop: "{{check_user_response.results}}"
-
-    # Facts are set only if the user has not been created yet
-    - name: Generating credentials
-      ansible.builtin.set_fact:
-        username: "{{item}}"
-        password: "{{lookup('community.general.random_string', length=12, special=false)}}"
-        host: "{{'10.0.1.%02d'|format(idx+11|int)}}"
-      loop: "{{lab_users}}"
-      loop_control:
-        index_var: idx
-      when: check_user_response.results[idx].status == 404
-      register: lab_credentials
-
-    # - name: Print facts
-    #   ansible.builtin.debug:
-    #     msg: "{{lab_credentials.results}}"
-
-    - name: Create lab users in guacamole
-      ansible.builtin.uri:
-        url: https://{{guacamole_fqdn}}/guacamole/api/session/data/postgresql/users?token={{create_token_response.json.authToken}}
-        validate_certs: false
-        method: POST
-        body_format: json
-        body:
-          username: "{{item.ansible_facts.username}}"
-          password: "{{item.ansible_facts.password}}"
-          attributes: {}
-        status_code: 200
-      loop: "{{lab_credentials.results}}"
-      when: "'ansible_facts' in item"
-      register: create_user_response
-      failed_when:
-        - create_user_response.status == 400
-        - "'already exists' not in create_user_response.json.message"
-
-    - name: Create a new connection
-      ansible.builtin.uri:
-        url: https://{{guacamole_fqdn}}/guacamole/api/session/data/postgresql/connections?token={{create_token_response.json.authToken}}
-        validate_certs: false
-        method: POST
-        body_format: json
-        body:
-          parentIdentifier: "ROOT"
-          name: "{{item.ansible_facts.username}}-rdp"
-          protocol: "rdp"
-          parameters:
-            hostname: "{{item.ansible_facts.host}}"
-            port: "3389"
-            username: "{{connection_username}}"
-            password: "{{connection_password}}"
-            server-layout: "it-it-qwerty"
-          attributes: {}
-        status_code: 200
-      loop: "{{lab_credentials.results}}"
-      when: "'ansible_facts' in item"
-      register: create_connection_response
-      failed_when:
-        - create_connection_response.status == 400
-        - "'already exists' not in create_connection_response.json.message"
-
-    # - name: Print create connection response
-    #   ansible.builtin.debug:
-    #     msg: "{{create_connection_response.results}}"
-
-    - name: Assign connection to user
-      ansible.builtin.uri:
-        url: https://{{guacamole_fqdn}}/guacamole/api/session/data/postgresql/users/{{item.ansible_facts.username}}/permissions?token={{create_token_response.json.authToken}}
-        validate_certs: false
-        method: PATCH
-        body_format: json
-        body:
-          - op: "add"
-            path: "/connectionPermissions/{{create_connection_response.results[idx].json.identifier}}"
-            value: "READ"
-        status_code: 204
-      loop: "{{lab_credentials.results}}"
-      loop_control:
-        index_var: idx
-      when:
-        - "'ansible_facts' in item"
-        - create_connection_response.results[idx].status == 200
-
-    - name: Delete token
-      ansible.builtin.uri:
-        url: https://{{guacamole_fqdn}}/guacamole/api/tokens/{{create_token_response.json.authToken}}
-        validate_certs: false
-        method: DELETE
-        status_code: 204
-
-    - name: Create credentials file
-      ansible.builtin.file:
-        path: "./{{lab_name}}/{{env}}/{{guacamole_fqdn}}_credentials.txt"
-        state: touch
-
-    - name: Write to credentials file
-      ansible.builtin.lineinfile:
-        path: "./{{lab_name}}/{{env}}/{{guacamole_fqdn}}_credentials.txt"
-        line: "{{item.ansible_facts.username}}::{{item.ansible_facts.password}}"
-        create: yes
-      loop: "{{lab_credentials.results}}"
-      when: "'ansible_facts' in item"
+        auth_username: "guacadmin"
+        auth_password: "guacadmin"
+        username: "{{ item }}"
+        password: "changeme"
+        allowed_connections: "{{ connections.results | map(attribute='connection_info.name') | select('match', item) | list }}"
+      loop: "{{ users }}"

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -18,6 +18,7 @@
         hostname: "{{ item.private_ip }}"
         username: "{{ item.user }}"
         password: "{{ item.password }}"
+        rdp_ignore_server_certs: true
       loop: "{{ instances }}"
       register: connections
 
@@ -30,4 +31,5 @@
         username: "{{ item }}"
         password: "changeme"
         allowed_connections: "{{ connections.results | map(attribute='connection_info.name') | select('match', item) | list }}"
+        expired: "true"
       loop: "{{ users }}"

--- a/bashly/openlab
+++ b/bashly/openlab
@@ -321,7 +321,7 @@ openlab_get_command() {
 
   cd $PWD/terraform
   terraform workspace select ${WORKSPACE} &> /dev/null || (echo "Lab \"${lab_name}\" does not exist" && exit 1)
-  echo "$(terraform output -raw hostname) ($(terraform output -raw state))"
+  echo "$(terraform output -raw lab_url) ($(terraform output -raw state))"
   cd $PWD/..
 
 }

--- a/bashly/openlab
+++ b/bashly/openlab
@@ -17,7 +17,7 @@ version_command() {
 
 # :command.usage
 openlab_usage() {
-  printf "openlab - openlab CLI\n\n"
+  printf "openlab - A CLI for managing lab environments\n\n"
 
   printf "%s\n" "Usage:"
   printf "  openlab COMMAND\n"
@@ -304,9 +304,9 @@ openlab_list_command() {
   # src/list_command.sh
   for i in $(ls $PWD/terraform/terraform.tfstate.d)
   do
-
-    LAB_NAME=$(echo ${i} | cut -d "-" -f 1)
-    ENV=$(echo ${i} | cut -d "-" -f 2)
+    TMP=$(echo ${i} | rev | awk '{sub(/-/,":")}1' | rev)
+    LAB_NAME=$(echo ${TMP} | cut -d ":" -f 1)
+    ENV=$(echo ${TMP} | cut -d ":" -f 2)
     echo "${LAB_NAME} (${ENV})"
   done
 
@@ -334,12 +334,20 @@ openlab_create_command() {
   WORKSPACE="${lab_name}-${ENV}"
 
   cd $PWD/terraform
+  echo "Creating lab ${lab_name} in ${ENV} environment..."
   terraform workspace select ${WORKSPACE} &> /dev/null || terraform workspace new ${WORKSPACE} &> /dev/null
   terraform apply -auto-approve -var="env=${ENV}"
-  echo "guacamole_fqdn: $(terraform output hostname)" > $PWD/../ansible/vars.yaml
+  LAB_URL=$(terraform output -json lab_url)
+  USERS=$(terraform output -json users)
+  INSTANCES=$(terraform output -json instances)
   cd $PWD/..
-  mkdir -p $PWD/ansible/${lab_name}/${ENV}
-  ansible-playbook $PWD/ansible/playbook.yaml --extra-vars "lab_name=${lab_name} env=${ENV}"
+  ansible-playbook $PWD/ansible/playbook.yaml \
+    --extra-vars "lab_name=${lab_name}" \
+    --extra-vars "env=${ENV}" \
+    --extra-vars "guacamole_url=${LAB_URL}" \
+    --extra-vars "users=${USERS}" \
+    --extra-vars "instances=${INSTANCES}"
+
 }
 
 # :command.function
@@ -354,8 +362,6 @@ openlab_delete_command() {
   terraform destroy -auto-approve -var="env=${ENV}"
   terraform workspace select default &> /dev/null && terraform workspace delete ${WORKSPACE} &> /dev/null
   cd $PWD/..
-  rm -rf $PWD/ansible/${lab_name}/${ENV}
-  if [ -z "$(ls -A $PWD/ansible/${lab_name})" ]; then rmdir $PWD/ansible/${lab_name}; fi
 }
 
 # :command.function

--- a/bashly/openlab
+++ b/bashly/openlab
@@ -302,13 +302,15 @@ inspect_args() {
 openlab_list_command() {
 
   # src/list_command.sh
+  TABLE="ENV,NAME"
   for i in $(ls $PWD/terraform/terraform.tfstate.d)
   do
     TMP=$(echo ${i} | rev | awk '{sub(/-/,":")}1' | rev)
     LAB_NAME=$(echo ${TMP} | cut -d ":" -f 1)
     ENV=$(echo ${TMP} | cut -d ":" -f 2)
-    echo "${LAB_NAME} (${ENV})"
+    TABLE="${TABLE}\n${ENV},${LAB_NAME}"
   done
+  (printf $TABLE | head -n 1 && printf $TABLE | tail -n +2 | sort) | column -t -s ','
 
 }
 
@@ -316,13 +318,17 @@ openlab_list_command() {
 openlab_get_command() {
 
   # src/get_command.sh
-  lab_name=${args[name]}
-  WORKSPACE="${lab_name}-${ENV}"
+  LAB_NAME=${args[name]}
+  WORKSPACE="${LAB_NAME}-${ENV}"
+  TABLE="ENV,NAME,URL,STATUS"
 
   cd $PWD/terraform
-  terraform workspace select ${WORKSPACE} &> /dev/null || (echo "Lab \"${lab_name}\" does not exist" && exit 1)
-  echo "$(terraform output -raw lab_url) ($(terraform output -raw state))"
+  terraform workspace select ${WORKSPACE} &> /dev/null || (echo "Lab \"${LAB_NAME}\" does not exist in ${ENV} environment" && exit 1)
+  URL=$(terraform output -raw lab_url)
+  STATUS=$(terraform output -raw state)
   cd $PWD/..
+  TABLE="${TABLE}\n${ENV},${LAB_NAME},${URL},${STATUS}"
+  printf $TABLE | column -t -s ','
 
 }
 
@@ -333,8 +339,9 @@ openlab_create_command() {
   lab_name=${args[name]}
   WORKSPACE="${lab_name}-${ENV}"
 
-  cd $PWD/terraform
   echo "Creating lab ${lab_name} in ${ENV} environment..."
+
+  cd $PWD/terraform
   terraform workspace select ${WORKSPACE} &> /dev/null || terraform workspace new ${WORKSPACE} &> /dev/null
   terraform apply -auto-approve -var="env=${ENV}"
   LAB_URL=$(terraform output -json lab_url)
@@ -357,8 +364,10 @@ openlab_delete_command() {
   lab_name=${args[name]}
   WORKSPACE="${lab_name}-${ENV}"
 
+  echo "Deleting lab ${lab_name} in ${ENV} environment..."
+
   cd $PWD/terraform
-  terraform workspace select ${WORKSPACE} &> /dev/null || (echo "Lab \"${lab_name}\" does not exist" && exit 1)
+  terraform workspace select ${WORKSPACE} &> /dev/null || (echo "Lab \"${lab_name}\" does not exist ${ENV} environment" && exit 1)
   terraform destroy -auto-approve -var="env=${ENV}"
   terraform workspace select default &> /dev/null && terraform workspace delete ${WORKSPACE} &> /dev/null
   cd $PWD/..
@@ -371,8 +380,10 @@ openlab_start_command() {
   lab_name=${args[name]}
   WORKSPACE="${lab_name}-${ENV}"
 
+  echo "Starting lab ${lab_name} in ${ENV} environment..."
+
   cd $PWD/terraform
-  terraform workspace select ${WORKSPACE} &> /dev/null || (echo "Lab \"${lab_name}\" does not exist" && exit 1)
+  terraform workspace select ${WORKSPACE} &> /dev/null || (echo "Lab \"${lab_name}\" does not exist in ${ENV} environment" && exit 1)
   terraform apply -auto-approve -var="env=${ENV}"
   cd $PWD/..
 
@@ -385,8 +396,10 @@ openlab_stop_command() {
   lab_name=${args[name]}
   WORKSPACE="${lab_name}-${ENV}"
 
+  echo "Stopping lab ${lab_name} in ${ENV} environment..."
+
   cd $PWD/terraform
-  terraform workspace select ${WORKSPACE} &> /dev/null || (echo "Lab \"${lab_name}\" does not exist" && exit 1)
+  terraform workspace select ${WORKSPACE} &> /dev/null || (echo "Lab \"${lab_name}\" does not exist ${ENV} environment" && exit 1)
   terraform apply -auto-approve -var="instance_state=stopped" -var="env=${ENV}"
   cd $PWD/..
 

--- a/bashly/src/create_command.sh
+++ b/bashly/src/create_command.sh
@@ -2,9 +2,16 @@ lab_name=${args[name]}
 WORKSPACE="${lab_name}-${ENV}"
 
 cd $PWD/terraform
+echo "Creating lab ${lab_name} in ${ENV} environment..."
 terraform workspace select ${WORKSPACE} &> /dev/null || terraform workspace new ${WORKSPACE} &> /dev/null
 terraform apply -auto-approve -var="env=${ENV}"
-echo "guacamole_fqdn: $(terraform output hostname)" > $PWD/../ansible/vars.yaml
+LAB_URL=$(terraform output -json lab_url)
+USERS=$(terraform output -json users)
+INSTANCES=$(terraform output -json instances)
 cd $PWD/..
-mkdir -p $PWD/ansible/${lab_name}/${ENV}
-ansible-playbook $PWD/ansible/playbook.yaml --extra-vars "lab_name=${lab_name} env=${ENV}"
+ansible-playbook $PWD/ansible/playbook.yaml \
+  --extra-vars "lab_name=${lab_name}" \
+  --extra-vars "env=${ENV}" \
+  --extra-vars "guacamole_url=${LAB_URL}" \
+  --extra-vars "users=${USERS}" \
+  --extra-vars "instances=${INSTANCES}"

--- a/bashly/src/create_command.sh
+++ b/bashly/src/create_command.sh
@@ -1,8 +1,9 @@
 lab_name=${args[name]}
 WORKSPACE="${lab_name}-${ENV}"
 
-cd $PWD/terraform
 echo "Creating lab ${lab_name} in ${ENV} environment..."
+
+cd $PWD/terraform
 terraform workspace select ${WORKSPACE} &> /dev/null || terraform workspace new ${WORKSPACE} &> /dev/null
 terraform apply -auto-approve -var="env=${ENV}"
 LAB_URL=$(terraform output -json lab_url)

--- a/bashly/src/delete_command.sh
+++ b/bashly/src/delete_command.sh
@@ -6,5 +6,3 @@ terraform workspace select ${WORKSPACE} &> /dev/null || (echo "Lab \"${lab_name}
 terraform destroy -auto-approve -var="env=${ENV}"
 terraform workspace select default &> /dev/null && terraform workspace delete ${WORKSPACE} &> /dev/null
 cd $PWD/..
-rm -rf $PWD/ansible/${lab_name}/${ENV}
-if [ -z "$(ls -A $PWD/ansible/${lab_name})" ]; then rmdir $PWD/ansible/${lab_name}; fi

--- a/bashly/src/delete_command.sh
+++ b/bashly/src/delete_command.sh
@@ -1,8 +1,10 @@
 lab_name=${args[name]}
 WORKSPACE="${lab_name}-${ENV}"
 
+echo "Deleting lab ${lab_name} in ${ENV} environment..."
+
 cd $PWD/terraform
-terraform workspace select ${WORKSPACE} &> /dev/null || (echo "Lab \"${lab_name}\" does not exist" && exit 1)
+terraform workspace select ${WORKSPACE} &> /dev/null || (echo "Lab \"${lab_name}\" does not exist ${ENV} environment" && exit 1)
 terraform destroy -auto-approve -var="env=${ENV}"
 terraform workspace select default &> /dev/null && terraform workspace delete ${WORKSPACE} &> /dev/null
 cd $PWD/..

--- a/bashly/src/get_command.sh
+++ b/bashly/src/get_command.sh
@@ -3,5 +3,5 @@ WORKSPACE="${lab_name}-${ENV}"
 
 cd $PWD/terraform
 terraform workspace select ${WORKSPACE} &> /dev/null || (echo "Lab \"${lab_name}\" does not exist" && exit 1)
-echo "$(terraform output -raw hostname) ($(terraform output -raw state))"
+echo "$(terraform output -raw lab_url) ($(terraform output -raw state))"
 cd $PWD/..

--- a/bashly/src/get_command.sh
+++ b/bashly/src/get_command.sh
@@ -1,7 +1,11 @@
-lab_name=${args[name]}
-WORKSPACE="${lab_name}-${ENV}"
+LAB_NAME=${args[name]}
+WORKSPACE="${LAB_NAME}-${ENV}"
+TABLE="ENV,NAME,URL,STATUS"
 
 cd $PWD/terraform
-terraform workspace select ${WORKSPACE} &> /dev/null || (echo "Lab \"${lab_name}\" does not exist" && exit 1)
-echo "$(terraform output -raw lab_url) ($(terraform output -raw state))"
+terraform workspace select ${WORKSPACE} &> /dev/null || (echo "Lab \"${LAB_NAME}\" does not exist in ${ENV} environment" && exit 1)
+URL=$(terraform output -raw lab_url)
+STATUS=$(terraform output -raw state)
 cd $PWD/..
+TABLE="${TABLE}\n${ENV},${LAB_NAME},${URL},${STATUS}"
+printf $TABLE | column -t -s ','

--- a/bashly/src/list_command.sh
+++ b/bashly/src/list_command.sh
@@ -1,6 +1,7 @@
 for i in $(ls $PWD/terraform/terraform.tfstate.d)
-do 
-  LAB_NAME=$(echo ${i} | cut -d "-" -f 1)
-  ENV=$(echo ${i} | cut -d "-" -f 2)
+do
+  TMP=$(echo ${i} | rev | awk '{sub(/-/,":")}1' | rev)
+  LAB_NAME=$(echo ${TMP} | cut -d ":" -f 1)
+  ENV=$(echo ${TMP} | cut -d ":" -f 2)
   echo "${LAB_NAME} (${ENV})"
 done

--- a/bashly/src/list_command.sh
+++ b/bashly/src/list_command.sh
@@ -1,7 +1,9 @@
+TABLE="ENV,NAME"
 for i in $(ls $PWD/terraform/terraform.tfstate.d)
 do
   TMP=$(echo ${i} | rev | awk '{sub(/-/,":")}1' | rev)
   LAB_NAME=$(echo ${TMP} | cut -d ":" -f 1)
   ENV=$(echo ${TMP} | cut -d ":" -f 2)
-  echo "${LAB_NAME} (${ENV})"
+  TABLE="${TABLE}\n${ENV},${LAB_NAME}"
 done
+(printf $TABLE | head -n 1 && printf $TABLE | tail -n +2 | sort) | column -t -s ','

--- a/bashly/src/start_command.sh
+++ b/bashly/src/start_command.sh
@@ -1,7 +1,9 @@
 lab_name=${args[name]}
 WORKSPACE="${lab_name}-${ENV}"
 
+echo "Starting lab ${lab_name} in ${ENV} environment..."
+
 cd $PWD/terraform
-terraform workspace select ${WORKSPACE} &> /dev/null || (echo "Lab \"${lab_name}\" does not exist" && exit 1)
+terraform workspace select ${WORKSPACE} &> /dev/null || (echo "Lab \"${lab_name}\" does not exist in ${ENV} environment" && exit 1)
 terraform apply -auto-approve -var="env=${ENV}"
 cd $PWD/..

--- a/bashly/src/stop_command.sh
+++ b/bashly/src/stop_command.sh
@@ -1,7 +1,9 @@
 lab_name=${args[name]}
 WORKSPACE="${lab_name}-${ENV}"
 
+echo "Stopping lab ${lab_name} in ${ENV} environment..."
+
 cd $PWD/terraform
-terraform workspace select ${WORKSPACE} &> /dev/null || (echo "Lab \"${lab_name}\" does not exist" && exit 1)
+terraform workspace select ${WORKSPACE} &> /dev/null || (echo "Lab \"${lab_name}\" does not exist ${ENV} environment" && exit 1)
 terraform apply -auto-approve -var="instance_state=stopped" -var="env=${ENV}"
 cd $PWD/..

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,24 +1,24 @@
-resource "aws_vpc" "ksp_vpc" {
+resource "aws_vpc" "openlab_vpc" {
   cidr_block           = "10.0.0.0/16"
   enable_dns_hostnames = true
   enable_dns_support   = true
 
   tags = {
-    Name = format("vpc-${terraform.workspace}")
+    Name = format("openlab-vpc-${terraform.workspace}")
   }
 }
 
 resource "aws_subnet" "frontend_subnet" {
-  vpc_id     = aws_vpc.ksp_vpc.id
+  vpc_id     = aws_vpc.openlab_vpc.id
   cidr_block = "10.0.0.0/24"
 }
 
 resource "aws_internet_gateway" "igw" {
-  vpc_id = aws_vpc.ksp_vpc.id
+  vpc_id = aws_vpc.openlab_vpc.id
 }
 
 resource "aws_default_route_table" "default_rtb" {
-  default_route_table_id = aws_vpc.ksp_vpc.default_route_table_id
+  default_route_table_id = aws_vpc.openlab_vpc.default_route_table_id
 
   route {
     cidr_block = "0.0.0.0/0"
@@ -36,8 +36,8 @@ resource "aws_nat_gateway" "nat_gtw" {
 }
 
 resource "aws_security_group" "frontend_sg" {
-  name   = "sg_frontend"
-  vpc_id = aws_vpc.ksp_vpc.id
+  name   = "frontend-security-group"
+  vpc_id = aws_vpc.openlab_vpc.id
 }
 
 resource "aws_vpc_security_group_ingress_rule" "allow_ssh" {
@@ -113,13 +113,14 @@ resource "aws_ec2_instance_state" "guacamole_frontend_instance_state" {
 /*     Backend    */
 /* ============== */
 
-resource "aws_subnet" "backend_subnet" {
-  vpc_id     = aws_vpc.ksp_vpc.id
-  cidr_block = "10.0.1.0/24"
+resource "aws_subnet" "backend_subnets" {
+  count      = length(var.lab_users)
+  vpc_id     = aws_vpc.openlab_vpc.id
+  cidr_block = format("10.0.%d.0/24", count.index + 1)
 }
 
 resource "aws_route_table" "backend_rtb" {
-  vpc_id = aws_vpc.ksp_vpc.id
+  vpc_id = aws_vpc.openlab_vpc.id
 
   route {
     cidr_block = "0.0.0.0/0"
@@ -128,17 +129,20 @@ resource "aws_route_table" "backend_rtb" {
 }
 
 resource "aws_route_table_association" "backend_rtb_assoc" {
+  count          = length(var.lab_users)
   route_table_id = aws_route_table.backend_rtb.id
-  subnet_id      = aws_subnet.backend_subnet.id
+  subnet_id      = aws_subnet.backend_subnets[count.index].id
 }
 
-resource "aws_security_group" "backend_sg" {
-  name   = "sg_backend"
-  vpc_id = aws_vpc.ksp_vpc.id
+resource "aws_security_group" "backend_security_groups" {
+  count  = length(var.lab_users)
+  name   = format("backend-security-group-%d", count.index + 1)
+  vpc_id = aws_vpc.openlab_vpc.id
 }
 
 resource "aws_vpc_security_group_ingress_rule" "allow_rdp" {
-  security_group_id = aws_security_group.backend_sg.id
+  count             = length(var.lab_users)
+  security_group_id = aws_security_group.backend_security_groups[count.index].id
 
   cidr_ipv4   = "10.0.0.10/32"
   from_port   = 3389
@@ -146,24 +150,46 @@ resource "aws_vpc_security_group_ingress_rule" "allow_rdp" {
   to_port     = 3389
 }
 
-resource "aws_vpc_security_group_egress_rule" "backend_sg_egress_rule" {
-  security_group_id = aws_security_group.backend_sg.id
+resource "aws_vpc_security_group_egress_rule" "allow_to_any" {
+  count             = length(var.lab_users)
+  security_group_id = aws_security_group.backend_security_groups[count.index].id
 
   cidr_ipv4   = "0.0.0.0/0"
   ip_protocol = -1
 }
 
-resource "aws_instance" "users_instances" {
-  count = length(var.lab_users)
+resource "aws_vpc_security_group_ingress_rule" "allow_from_subnet" {
+  count             = length(var.lab_users)
+  security_group_id = aws_security_group.backend_security_groups[count.index].id
 
-  ami                    = var.instance_ami
-  instance_type          = var.instance_type
-  subnet_id              = aws_subnet.backend_subnet.id
-  private_ip             = format("10.0.1.%d", count.index + 1 + 10)
-  vpc_security_group_ids = [aws_security_group.backend_sg.id]
+  cidr_ipv4   = aws_subnet.backend_subnets[count.index].cidr_block
+  ip_protocol = -1
+}
+
+locals {
+  instances = [
+    for key, pair in setproduct(aws_subnet.backend_subnets, var.instances) : {
+      ami           = pair[1].ami
+      instance_type = pair[1].instance_type
+      subnet_id     = pair[0].id
+      private_ip    = cidrhost(pair[0].cidr_block, key % length(var.instances) + 11)
+    }
+  ]
+}
+
+resource "aws_instance" "users_instances" {
+  for_each = tomap({
+    for key, instance in local.instances : key => instance
+  })
+
+  ami                    = each.value.ami
+  instance_type          = each.value.instance_type
+  subnet_id              = each.value.subnet_id
+  private_ip             = each.value.private_ip
+  vpc_security_group_ids = [aws_security_group.backend_security_groups[floor(each.key / length(var.instances))].id]
 
   tags = {
-    Name = format("user-%02.0f-ec2-${terraform.workspace}", count.index + 1)
+    Name = format("user-%02.0f-ec2-${terraform.workspace}", floor(each.key / length(var.instances)) + 1)
   }
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -173,6 +173,9 @@ locals {
       instance_type = pair[1].instance_type
       subnet_id     = pair[0].id
       private_ip    = cidrhost(pair[0].cidr_block, key % length(var.instances) + 11)
+      user          = pair[1].user
+      password      = pair[1].password
+      owner         = var.lab_users[floor(key / length(var.instances))]
     }
   ]
 }

--- a/terraform/output.tf
+++ b/terraform/output.tf
@@ -1,9 +1,19 @@
-output "hostname" {
-  description = "Guacamole hostname"
-  value       = format("guacamole.%s.sslip.io", aws_eip.frontend_ip.public_ip)
+output "lab_url" {
+  description = "Guacamole URL"
+  value       = format("https://guacamole.%s.sslip.io", aws_eip.frontend_ip.public_ip)
 }
 
 output "state" {
   description = "Lab state"
   value       = aws_ec2_instance_state.guacamole_frontend_instance_state.state
+}
+
+output "instances" {
+  description = "Lab VMs"
+  value       = local.instances
+}
+
+
+output "users" {
+  value = [for user in var.lab_users : user]
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -10,13 +10,13 @@ variable "env" {
 
 variable "region" {
   description = "AWS region where the lab environment will be instantiated"
-  type = string
+  type        = string
 }
 
 variable "guacamole_ami" {
   description = "AMI to be used for guacamole instance. It must exist before provisioning."
-  type = string
-  default = "ami-040f47e4ddbe2ee13" # pointing to ubuntu 24.04 AMI
+  type        = string
+  default     = "ami-040f47e4ddbe2ee13" # pointing to ubuntu 24.04 AMI
 }
 
 variable "guacamole_instance_type" {
@@ -26,7 +26,16 @@ variable "guacamole_instance_type" {
 
 variable "guacamole_ssh_key" {
   description = "Name of SSH key pair stored in AWS. Use it only for debugging operations. The username depends on the AMI used."
-  type = string
+  type        = string
+}
+
+variable "instances" {
+  type = list(object({
+    ami           = string
+    instance_type = string
+    user          = string
+    password      = string
+  }))
 }
 
 variable "lab_users" {
@@ -45,26 +54,26 @@ variable "instance_state" {
   }
 }
 
-variable "instance_ami" {
-  description = "AMI to be used for user instances. It must exist before provisioning."
-  type        = string
-}
+# variable "instance_ami" {
+#   description = "AMI to be used for user instances. It must exist before provisioning."
+#   type        = string
+# }
 
-variable "instance_type" {
-  type    = string
-  default = "t3.medium"
-}
+# variable "instance_type" {
+#   type    = string
+#   default = "t3.medium"
+# }
 
-variable "connection_username" {
-  description = "Username for the guacamole RDP connection. Depends on pre-configured lab user instance."
-  type        = string
-}
+# variable "connection_username" {
+#   description = "Username for the guacamole RDP connection. Depends on pre-configured lab user instance."
+#   type        = string
+# }
 
-variable "connection_password" {
-  description = "Password for the guacamole RDP connection. Depends on pre-configured lab user instance."
-  type        = string
-  sensitive   = true
-}
+# variable "connection_password" {
+#   description = "Password for the guacamole RDP connection. Depends on pre-configured lab user instance."
+#   type        = string
+#   sensitive   = true
+# }
 
 variable "postgres_user" {
   description = "Postgres administrator username"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -54,43 +54,25 @@ variable "instance_state" {
   }
 }
 
-# variable "instance_ami" {
-#   description = "AMI to be used for user instances. It must exist before provisioning."
-#   type        = string
-# }
-
-# variable "instance_type" {
-#   type    = string
-#   default = "t3.medium"
-# }
-
-# variable "connection_username" {
-#   description = "Username for the guacamole RDP connection. Depends on pre-configured lab user instance."
-#   type        = string
-# }
-
-# variable "connection_password" {
-#   description = "Password for the guacamole RDP connection. Depends on pre-configured lab user instance."
-#   type        = string
-#   sensitive   = true
-# }
-
 variable "postgres_user" {
   description = "Postgres administrator username"
   type        = string
   sensitive   = true
+  default     = "postgres"
 }
 
 variable "postgres_password" {
   description = "Postgres administrator password"
   type        = string
   sensitive   = true
+  default     = "secret"
 }
 
 variable "postgres_db" {
   description = "Postgres database"
   type        = string
   sensitive   = true
+  default     = "guacamole"
 }
 
 variable "acme_letsencrypt_endpoint" {


### PR DESCRIPTION
**Description:**
This pull request implements the enhancement to allow the creation of multiple VMs for each lab user during lab provisioning. The changes enable instructors and administrators to define the number and type of VMs assigned to each user, supporting more complex and realistic lab scenarios.

**Key Changes:**
Updated the openlab CLI, Terraform modules, and Ansible playbooks to accept and process a configuration parameter specifying the number of VMs per user.
Modified the provisioning workflow to create and configure the specified number of VMs for each user.
Ensured that all VMs are registered in Guacamole, with unique connection details for each user and VM.
Enhanced documentation to explain how to configure and use this new feature.